### PR TITLE
Make sure esip_codec isn't compiled to native code

### DIFF
--- a/src/esip_codec.erl
+++ b/src/esip_codec.erl
@@ -23,6 +23,8 @@
 
 -module(esip_codec).
 
+-compile(no_native).
+
 %% API
 -export([start/0,
          decode/1,


### PR DESCRIPTION
NIFs [cannot](http://erlang.org/pipermail/erlang-questions/2011-June/059237.html) be loaded from a HiPE-compiled module.
