### PR TITLE
Use include_lib to find library includes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,8 +22,6 @@
 
 {erl_opts, [debug_info, {src_dirs, ["src"]},
             {i, "include"},
-	    {i, "deps/stun/include"},
-	    {i, "../stun/include"},
 	    {if_have_fun, {crypto, strong_rand_bytes, 1}, {d, 'STRONG_RAND_BYTES'}},
 	    {if_have_fun, {rand, uniform, 1}, {d, 'RAND_UNIFORM'}}]}.
 

--- a/src/esip_socket.erl
+++ b/src/esip_socket.erl
@@ -37,7 +37,7 @@
 
 -include("esip.hrl").
 -include("esip_lib.hrl").
--include("stun.hrl").
+-include_lib("stun/include/stun.hrl").
 
 -define(TCP_SEND_TIMEOUT, 15000).
 -define(CONNECT_TIMEOUT, 20000).


### PR DESCRIPTION
Use include_lib for stun.hrl include to support compilation with rebar3