### PR TITLE
PullRequest_erlang-p1-sip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - ppc64le
+  - amd64
 language: erlang
 
 os: linux
@@ -6,6 +9,7 @@ dist: xenial
 
 before_install:
   - pip install --user cpp-coveralls coveralls-merge
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 
 install:
   - ./configure
@@ -19,3 +23,14 @@ otp_release:
   - 18.1
   - 22.3
   - 23.0
+
+# Disable otp_release 17.1, 17.5, 18.1, 19.3 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    otp_release: 17.1
+  - arch: ppc64le
+    otp_release: 17.5
+  - arch: ppc64le
+    otp_release: 18.1
+  


### PR DESCRIPTION
Following changes are made in this commit to Travis.yml
Excluding Jobs for otp_releases:17.1/17.5/18.1 as these are not supported on Ubuntu16.04 with arch: ppc64le
And added a new line under "before_install" to make the build run for sotp_releases:22.3/23.0 which are supported on Ubuntu16.04 with arch: ppc64le.